### PR TITLE
Use right binary name to format code in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "index.js"
   ],
   "scripts": {
-    "format": "run -p format:js format:md",
+    "format": "run-p format:js format:md",
     "format:js": "yarn run lint:js --fix",
     "format:md": "yarn run lint:md -- --fix",
     "lint": "run-p lint:js lint:md",


### PR DESCRIPTION
## :construction_worker: Build

e4e8bdf - build: use right binary name to format code in parallel

## :link: Related

Closes #13

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>