### PR TITLE
Stop displaying warning when formatting .md files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "format": "run -p format:js format:md",
     "format:js": "yarn run lint:js --fix",
-    "format:md": "yarn run lint:md -- --fix",
+    "format:md": "yarn run lint:md --fix",
     "lint": "run-p lint:js lint:md",
     "lint:js": "eslint --quiet index.js",
     "lint:md": "eslint --quiet --format=pretty --ext .md .",


### PR DESCRIPTION
## :construction_worker: Build

49775ea  - build: stop displaying warning when formatting .md files

## :link: Related

Closes #15

Signed-off-by: Antoine Leblanc <antoine.leblanc@ovhcloud.com>